### PR TITLE
Point the contact links at hi@alexxie.com

### DIFF
--- a/src/components/Bio/About.tsx
+++ b/src/components/Bio/About.tsx
@@ -28,7 +28,7 @@ const About = () => {
       <div>
         <Text as="p">
           Wanna chat about <Text bold>{talkingPoint}</Text>?{' '}
-          <Link href="mailto:hey@alexxie.com">Get in touch</Link>.
+          <Link href="mailto:hi@alexxie.com">Get in touch</Link>.
         </Text>
       </div>
     </>

--- a/src/components/Bio/Work.tsx
+++ b/src/components/Bio/Work.tsx
@@ -51,7 +51,7 @@ const Work: FC = memo(() => {
 
       <Text as="p">
         Want to learn more or connect? Shoot me a message at{' '}
-        <Link href="mailto:hey@alexxie.com">hey@alexxie.com</Link>.
+        <Link href="mailto:hi@alexxie.com">hi@alexxie.com</Link>.
       </Text>
     </>
   );


### PR DESCRIPTION
## Summary

Every email address the site shows now points at `hi@alexxie.com` instead of `hey@alexxie.com`. That is two places, three occurrences: the "Get in touch" link in the About copy, and the address spelled out in the Work copy (both the `mailto:` and the visible text).

## Why this change is needed

Switching the address the site hands out.

Nothing else in the repo needed touching — the only other matches for an email-shaped string are the Redis connection URL in `storage.ts` and the release bot's git identity in `release.yml`, neither of which is a contact address.

## Test plan

- [x] No `hey@` remains anywhere in `src` or `public`
- [x] Both sections render `mailto:hi@alexxie.com`, with the Work copy showing the address as its text
- [x] Typecheck, lint and format all clean

Made with [Cursor](https://cursor.com)