### PR TITLE
Vercel patch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2026.8.3",
       "license": "MIT",
       "dependencies": {
+        "@vercel/analytics": "^2.0.1",
         "goober": "^2.1.19",
         "goober-autoprefixer": "^1.2.3",
         "ioredis": "^6.0.0",
@@ -2129,6 +2130,48 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/acorn": {
       "version": "8.18.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "typescript-eslint": "^8.67.0"
   },
   "dependencies": {
+    "@vercel/analytics": "^2.0.1",
     "goober": "^2.1.19",
     "goober-autoprefixer": "^1.2.3",
     "ioredis": "^6.0.0",

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,7 +1,13 @@
 import type { AppProps } from 'next/app';
+import { Analytics } from '@vercel/analytics/next';
 
 import '../styles/globals.css';
 
 export default function App({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />;
+  return (
+    <>
+      <Component {...pageProps} />
+      <Analytics />
+    </>
+  );
 }


### PR DESCRIPTION
## Summary

Installs `@vercel/analytics` and mounts `<Analytics />` alongside the page in `pages/_app.tsx`, following Vercel's own setup steps.

## Why this change is needed

Vercel patch — the platform's own drop-in, set up the way Vercel documents it.

## Notes

The `/next` entrypoint reads the route through `useParams` / `useSearchParams` from `next/navigation`. Both return `null` while a Pages Router page is prerendering, and the component early-returns in that case, so static generation is unaffected — verified by a clean production build of `/`.

## Test plan

- [x] Typecheck, lint, format and production build all clean; `/` still prerenders as SSG
- [x] On a production server the script mounts with the expected SDK name and defer, and the client queue initialises
- [x] No hydration or runtime errors; the room, the section toggle and the contact link all still work
- [x] Nothing moved visually — dark, light and mobile all render as before, with no horizontal overflow

Made with [Cursor](https://cursor.com)